### PR TITLE
typo fix: PyLaides -> PyLadies

### DIFF
--- a/about.md
+++ b/about.md
@@ -22,7 +22,7 @@ Read his papers:
 Join his groups:
 
 * [Grand Rapids Python Users Group](https://www.meetup.com/grpython/)
-* [PyLaides Grand Rapids](https://www.meetup.com/PyLadiesGrandRapids/)
+* [PyLadies Grand Rapids](https://www.meetup.com/PyLadiesGrandRapids/)
 * [Citizen Labs](https://citizenlabs.org/)
 
 -----


### PR DESCRIPTION
Quick fix for a typo I cam across